### PR TITLE
Updated IPCAM module. The files need to be in binmode for writing in Windows

### DIFF
--- a/fhem/FHEM/49_IPCAM.pm
+++ b/fhem/FHEM/49_IPCAM.pm
@@ -409,6 +409,7 @@ IPCAM_getSnapshot($) {
       readingsEndUpdate($hash, defined($hash->{LOCAL} ? 0 : 1));
       return undef;
     }
+    binmode(FH);
     print FH $snapshot;
     close(FH);
     Log 5, "IPCAM $name snapshot $storage/$lastSnapshot written.";
@@ -418,6 +419,7 @@ IPCAM_getSnapshot($) {
       readingsEndUpdate($hash, defined($hash->{LOCAL} ? 0 : 1));
       return undef;
     }
+    binmode(FH);
     print FH $snapshot;
     close(FH);
     Log 5, "IPCAM $name snapshot $storage/$imageFile written.";


### PR DESCRIPTION
Please also test this with Linux. Although it should work without problems.

If this is not done, the jpeg files will have linefeed errors (and cannot be opened) if IPCAM is used with Windows.

See http://perldoc.perl.org/functions/binmode.html for more information on binmode.
